### PR TITLE
要求するpythonバージョンを3.11以上から3.10以上に修正

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ packages = [
 ]
 
 [tool.poetry.dependencies]
-python = "^3.11"
+python = "^3.10"
 openai = "^1.35.5"
 langchain = "^0.1.20"
 python-dotenv = ">=0.20.0,<2.0.0"


### PR DESCRIPTION
3.11以上を必要とするパッケージを使用していなかったため修正